### PR TITLE
Fix for last chunk

### DIFF
--- a/ml_ephys/preprocessing/p_mask_out_artifacts.py
+++ b/ml_ephys/preprocessing/p_mask_out_artifacts.py
@@ -161,7 +161,11 @@ def mask_chunk(num, use_it):
     chunk = X.readChunk(i1=0, N1=X.N1(), i2=t1, N2=t2 - t1).astype(np.float32)  # Read the chunk
 
     if sum(use_it) != len(use_it):
-        chunk[:, get_masked_indices(use_it, write_chunk_size, chunk_size, num_write_chunks)] = 0
+        idmax = t2 - t1
+        idx = get_masked_indices(use_it, write_chunk_size, chunk_size, num_write_chunks)
+        if idx[-1]>=idmax:
+            idx = idx[idx < idmax]
+        chunk[:, idx] = 0
 
     ###########################################################################################
     # Now we wait until we are ready to append to the output file


### PR DESCRIPTION
Hi Jeremy, I was testing an old pipeline and I got an IndexError when mask_out_artifacts set to zero the last chunk. The segmentation of chunks creates a smaller chunk for the last samples. However, the function get_masked_indices() does not check that and It could return indices over the number of samples.